### PR TITLE
Refactor custom content rendering

### DIFF
--- a/app/uk/gov/hmrc/uploaddocuments/controllers/BaseController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/BaseController.scala
@@ -90,10 +90,10 @@ abstract class BaseController(
       case _    => body
     }
 
-  final def withJourneyConfig(
+  final def withJourneyContext(
     body: FileUploadContext => Future[Result]
   )(implicit request: Request[_], ec: ExecutionContext): Future[Result] =
-    components.newJourneyCacheRepository.get(currentJourneyId)(DataKeys.journeyConfigDataKey) flatMap {
+    components.newJourneyCacheRepository.get(currentJourneyId)(DataKeys.journeyContextDataKey) flatMap {
       case Some(journey) => body(journey)
       case _             => Future.successful(Redirect(components.appConfig.govukStartUrl))
     }

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/ChooseMultipleFilesController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/ChooseMultipleFilesController.scala
@@ -63,7 +63,6 @@ class ChooseMultipleFilesController @Inject() (
     }
 
   private def renderView(context: FileUploadContext, files: FileUploads, form: Form[Boolean])(implicit
-    hc: HeaderCarrier,
     request: Request[_]
   ) =
     uploadMultipleFilesView(

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/ChooseMultipleFilesController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/ChooseMultipleFilesController.scala
@@ -42,15 +42,16 @@ class ChooseMultipleFilesController @Inject() (
     Action.async { implicit request =>
       whenInSession {
         whenAuthenticated {
-          withJourneyConfig { journeyConfig =>
+          withJourneyContext { journeyConfig =>
             withUploadedFiles { files =>
               val sessionStateUpdate =
                 JourneyModel.toUploadMultipleFiles(router.preferUploadMultipleFiles)
               sessionStateService
                 .updateSessionState(sessionStateUpdate)
                 .map {
-                  case (_: State.UploadMultipleFiles, _) =>
-                    Ok(renderView(journeyConfig, files, YesNoChoiceForm))
+                  case (uploadMultipleFiles: State.UploadMultipleFiles, _) =>
+                    // TODO: Change this to use the files from 'withUploadedFiles' once that is actually updated
+                    Ok(renderView(journeyConfig, uploadMultipleFiles.fileUploads, YesNoChoiceForm))
 
                   case other =>
                     router.redirectTo(other)

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/ChooseMultipleFilesController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/ChooseMultipleFilesController.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.uploaddocuments.controllers
 
 import play.api.data.Form
 import play.api.mvc.{Action, AnyContent, Call, Request}
-import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.uploaddocuments.controllers.Forms.YesNoChoiceForm
 import uk.gov.hmrc.uploaddocuments.journeys.{JourneyModel, State}
 import uk.gov.hmrc.uploaddocuments.models.{FileUploadContext, FileUploads}
@@ -76,15 +75,16 @@ class ChooseMultipleFilesController @Inject() (
         .getOrElse(context.config.allowedContentTypes),
       context.config.newFileDescription,
       initialFileUploads = files.files,
-      initiateNextFileUpload = router.initiateNextFileUpload,
-      checkFileVerificationStatus = router.checkFileVerificationStatus,
-      removeFile = router.removeFileUploadByReferenceAsync,
-      previewFile = router.previewFileUploadByReference,
-      markFileRejected = router.markFileUploadAsRejectedAsync,
-      continueAction =
-        if (context.config.features.showYesNoQuestionBeforeContinue)
-          router.continueWithYesNo
-        else router.continueToHost,
+      initiateNextFileUpload = routes.InitiateUpscanController.initiateNextFileUpload,
+      checkFileVerificationStatus = routes.FileVerificationController.checkFileVerificationStatus,
+      removeFile = routes.RemoveController.removeFileUploadByReferenceAsync,
+      previewFile = routes.PreviewController.previewFileUploadByReference,
+      markFileRejected = routes.FileRejectedController.markFileUploadAsRejectedAsync,
+      continueAction = if (context.config.features.showYesNoQuestionBeforeContinue) {
+        routes.ContinueToHostController.continueWithYesNo
+      } else {
+        routes.ContinueToHostController.continueToHost
+      },
       backLink = Call("GET", context.config.backlinkUrl),
       context.config.features.showYesNoQuestionBeforeContinue,
       context.config.content.yesNoQuestionText,

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/ChooseSingleFileController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/ChooseSingleFileController.scala
@@ -16,12 +16,10 @@
 
 package uk.gov.hmrc.uploaddocuments.controllers
 
-import play.api.mvc.Results.Ok
 import play.api.mvc.{Action, AnyContent, Request}
-import uk.gov.hmrc.govukfrontend.views.viewmodels.breadcrumbs.Breadcrumbs
 import uk.gov.hmrc.uploaddocuments.connectors.UpscanInitiateConnector
 import uk.gov.hmrc.uploaddocuments.journeys.{JourneyModel, State}
-import uk.gov.hmrc.uploaddocuments.models.{FileUploadContext, FileUploadInitializationRequest}
+import uk.gov.hmrc.uploaddocuments.models.FileUploadContext
 import uk.gov.hmrc.uploaddocuments.services.SessionStateService
 import uk.gov.hmrc.uploaddocuments.views.html.UploadSingleFileView
 
@@ -44,7 +42,7 @@ class ChooseSingleFileController @Inject() (
     Action.async { implicit request =>
       whenInSession {
         whenAuthenticated {
-          withJourneyConfig { journeyConfig =>
+          withJourneyContext { journeyConfig =>
             val sessionStateUpdate =
               JourneyModel
                 .initiateFileUpload(upscanRequest(currentJourneyId))(upscanInitiateConnector.initiate(_, _))
@@ -52,6 +50,7 @@ class ChooseSingleFileController @Inject() (
               .updateSessionState(sessionStateUpdate)
               .map {
                 case (uploadSingleFile: State.UploadSingleFile, breadcrumbs) =>
+                  // TODO: Change in future to retrieve state from Mongo rather than SessionStateService
                   Ok(renderView(journeyConfig, uploadSingleFile, breadcrumbs))
 
                 case other =>

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/ChooseSingleFileController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/ChooseSingleFileController.scala
@@ -75,9 +75,9 @@ class ChooseSingleFileController @Inject() (
       uploadRequest = uploadSingleFile.uploadRequest,
       fileUploads = uploadSingleFile.fileUploads,
       maybeUploadError = uploadSingleFile.maybeUploadError,
-      successAction = router.showSummary,
-      failureAction = router.showChooseSingleFile,
-      checkStatusAction = router.checkFileVerificationStatus(uploadSingleFile.reference),
+      successAction = routes.SummaryController.showSummary,
+      failureAction = routes.ChooseSingleFileController.showChooseFile,
+      checkStatusAction = routes.FileVerificationController.checkFileVerificationStatus(uploadSingleFile.reference),
       backLink = renderer.backlink(breadcrumbs)
     )(implicitly[Request[_]], journeyConfig.messages, journeyConfig.config.features, journeyConfig.config.content)
 }

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/FilePostedController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/FilePostedController.scala
@@ -16,22 +16,20 @@
 
 package uk.gov.hmrc.uploaddocuments.controllers
 
-import akka.actor.ActorSystem
+import play.api.http.HeaderNames
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.uploaddocuments.journeys.JourneyModel
 import uk.gov.hmrc.uploaddocuments.services.SessionStateService
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
-import play.api.http.HeaderNames
 
 @Singleton
 class FilePostedController @Inject() (
   sessionStateService: SessionStateService,
   router: Router,
   renderer: Renderer,
-  components: BaseControllerComponents,
-  actorSystem: ActorSystem
+  components: BaseControllerComponents
 )(implicit ec: ExecutionContext)
     extends BaseController(components) {
 

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/FileRejectedController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/FileRejectedController.scala
@@ -16,22 +16,20 @@
 
 package uk.gov.hmrc.uploaddocuments.controllers
 
-import akka.actor.ActorSystem
+import play.api.http.HeaderNames
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.uploaddocuments.journeys.JourneyModel
 import uk.gov.hmrc.uploaddocuments.services.SessionStateService
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
-import play.api.http.HeaderNames
 
 @Singleton
 class FileRejectedController @Inject() (
   sessionStateService: SessionStateService,
   router: Router,
   renderer: Renderer,
-  components: BaseControllerComponents,
-  actorSystem: ActorSystem
+  components: BaseControllerComponents
 )(implicit ec: ExecutionContext)
     extends BaseController(components) {
 

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/FileVerificationController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/FileVerificationController.scala
@@ -78,9 +78,9 @@ class FileVerificationController @Inject() (
     request: Request[_]
   ) =
     waitingView(
-      successAction = router.showSummary,
-      failureAction = router.showChooseSingleFile,
-      checkStatusAction = router.checkFileVerificationStatus(reference),
+      successAction = routes.SummaryController.showSummary,
+      failureAction = routes.ChooseSingleFileController.showChooseFile,
+      checkStatusAction = routes.FileVerificationController.checkFileVerificationStatus(reference),
       backLink = renderer.backlink(breadcrumbs)
     )(implicitly[Request[_]], context.messages, context.config.features, context.config.content)
 
@@ -111,7 +111,7 @@ class FileVerificationController @Inject() (
                 FileVerificationStatus(
                   file,
                   uploadFileViewHelper,
-                  router.previewFileUploadByReference(_, _),
+                  routes.PreviewController.previewFileUploadByReference(_, _),
                   s.context.config.maximumFileSizeBytes.toInt,
                   s.context.config.content.allowedFilesTypesHint
                     .orElse(s.context.config.allowedFileExtensions)

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/InitiateUpscanController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/InitiateUpscanController.scala
@@ -16,9 +16,7 @@
 
 package uk.gov.hmrc.uploaddocuments.controllers
 
-import akka.actor.ActorSystem
 import play.api.libs.json.Json
-import play.api.mvc.Results.{Forbidden, NotFound, Ok}
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.uploaddocuments.connectors.UpscanInitiateConnector
 import uk.gov.hmrc.uploaddocuments.journeys.{JourneyModel, State}
@@ -34,8 +32,7 @@ class InitiateUpscanController @Inject() (
   upscanInitiateConnector: UpscanInitiateConnector,
   val router: Router,
   renderer: Renderer,
-  components: BaseControllerComponents,
-  actorSystem: ActorSystem
+  components: BaseControllerComponents
 )(implicit ec: ExecutionContext)
     extends BaseController(components) with UpscanRequestSupport {
 

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/PreviewController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/PreviewController.scala
@@ -16,23 +16,25 @@
 
 package uk.gov.hmrc.uploaddocuments.controllers
 
+import akka.actor.ActorSystem
 import play.api.mvc.{Action, AnyContent}
-import uk.gov.hmrc.uploaddocuments.connectors.{FileUploadResultPushConnector, UpscanInitiateConnector}
+import play.mvc.Http.HeaderNames
+import uk.gov.hmrc.uploaddocuments.connectors.FileStream
+import uk.gov.hmrc.uploaddocuments.journeys.State
+import uk.gov.hmrc.uploaddocuments.models.{FileUpload, RFC3986Encoder}
 import uk.gov.hmrc.uploaddocuments.services.SessionStateService
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class PreviewController @Inject() (
   sessionStateService: SessionStateService,
-  upscanInitiateConnector: UpscanInitiateConnector,
-  fileUploadResultPushConnector: FileUploadResultPushConnector,
-  router: Router,
   renderer: Renderer,
-  components: BaseControllerComponents
+  components: BaseControllerComponents,
+  val actorSystem: ActorSystem
 )(implicit ec: ExecutionContext)
-    extends BaseController(components) {
+    extends BaseController(components) with FileStream {
 
   // GET /preview/:reference/:fileName
   final def previewFileUploadByReference(reference: String, fileName: String): Action[AnyContent] =
@@ -42,12 +44,35 @@ class PreviewController @Inject() (
           sessionStateService.currentSessionState
             .flatMap {
               case Some((state, _)) =>
-                renderer.streamFileFromUspcan(reference)(state)
+                streamFileFromUspcan(reference)(state)
 
               case None =>
                 NotFound.asFuture
             }
         }
       }
+    }
+
+  private def streamFileFromUspcan(reference: String) =
+    renderer.asyncResultOf {
+      case s: State.HasFileUploads =>
+        s.fileUploads.files.find(_.reference == reference) match {
+          case Some(file: FileUpload.Accepted) =>
+            getFileStream(
+              url = file.url,
+              fileName = file.fileName,
+              fileMimeType = file.fileMimeType,
+              fileSize = file.fileSize,
+              contentDispositionForMimeType = (fileName, fileMimeType) =>
+                fileMimeType match {
+                  case _ =>
+                    HeaderNames.CONTENT_DISPOSITION ->
+                      s"""inline; filename="${fileName.filter(_.toInt < 128)}"; filename*=utf-8''${RFC3986Encoder
+                        .encode(fileName)}"""
+                }
+            )
+          case _ => Future.successful(NotFound)
+        }
+      case _ => Future.successful(NotFound)
     }
 }

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/RemoveController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/RemoveController.scala
@@ -30,7 +30,6 @@ class RemoveController @Inject() (
   upscanInitiateConnector: UpscanInitiateConnector,
   fileUploadResultPushConnector: FileUploadResultPushConnector,
   val router: Router,
-  renderer: Renderer,
   components: BaseControllerComponents
 )(implicit ec: ExecutionContext)
     extends BaseController(components) with UpscanRequestSupport {

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/Renderer.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/Renderer.scala
@@ -16,119 +16,17 @@
 
 package uk.gov.hmrc.uploaddocuments.controllers
 
-import akka.actor.ActorSystem
-import play.api.data.Form
-import play.api.i18n.Messages
-import play.api.libs.json.Json
 import play.api.mvc.Results._
 import play.api.mvc._
 import play.mvc.Http.HeaderNames
-import uk.gov.hmrc.uploaddocuments.connectors._
-import uk.gov.hmrc.uploaddocuments.controllers.Forms._
 import uk.gov.hmrc.uploaddocuments.journeys.State
-import uk.gov.hmrc.uploaddocuments.models._
-import uk.gov.hmrc.uploaddocuments.views.UploadFileViewHelper
-import uk.gov.hmrc.uploaddocuments.wiring.AppConfig
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.Future
 
 /** Component responsible for translating given session state into the action result. */
 @Singleton
-class Renderer @Inject() (
-  views: uk.gov.hmrc.uploaddocuments.views.FileUploadViews,
-  uploadFileViewHelper: UploadFileViewHelper,
-  router: Router,
-  appConfig: AppConfig,
-  val actorSystem: ActorSystem
-) extends FileStream {
-
-  import uk.gov.hmrc.uploaddocuments.support.OptionalFormOps._
-
-  final def display(state: State, breadcrumbs: List[State], formWithErrors: Option[Form[_]])(implicit
-    request: Request[_],
-    m: Messages
-  ): Result =
-    state match {
-
-      case State.Summary(context, fileUploads, _) =>
-        Ok(
-          if (fileUploads.acceptedCount < context.config.maximumNumberOfFiles)
-            views.summaryView(
-              maxFileUploadsNumber = context.config.maximumNumberOfFiles,
-              maximumFileSizeBytes = context.config.maximumFileSizeBytes,
-              formWithErrors.or(YesNoChoiceForm),
-              fileUploads,
-              router.submitUploadAnotherFileChoice,
-              router.previewFileUploadByReference,
-              router.removeFileUploadByReference,
-              backlink(breadcrumbs)
-            )(implicitly[Request[_]], context.messages, context.config.features, context.config.content)
-          else
-            views.summaryNoChoiceView(
-              context.config.maximumNumberOfFiles,
-              fileUploads,
-              router.continueToHost,
-              router.previewFileUploadByReference,
-              router.removeFileUploadByReference,
-              Call("GET", context.config.backlinkUrl)
-            )(implicitly[Request[_]], context.messages, context.config.features, context.config.content)
-        )
-
-      case _ => NotImplemented
-    }
-
-  final def renderFileVerificationStatus(
-    reference: String
-  )(implicit messages: Messages) =
-    resultOf {
-      case s: State.FileUploadState =>
-        s.fileUploads.files.find(_.reference == reference) match {
-          case Some(file) =>
-            Ok(
-              Json.toJson(
-                FileVerificationStatus(
-                  file,
-                  uploadFileViewHelper,
-                  router.previewFileUploadByReference(_, _),
-                  s.context.config.maximumFileSizeBytes.toInt,
-                  s.context.config.content.allowedFilesTypesHint
-                    .orElse(s.context.config.allowedFileExtensions)
-                    .getOrElse(s.context.config.allowedContentTypes)
-                )
-              )
-            )
-          case None => NotFound
-        }
-      case _ => NotFound
-    }
-
-  final def streamFileFromUspcan(
-    reference: String
-  ) =
-    asyncResultOf {
-      case s: State.HasFileUploads =>
-        s.fileUploads.files.find(_.reference == reference) match {
-          case Some(file: FileUpload.Accepted) =>
-            getFileStream(
-              file.url,
-              file.fileName,
-              file.fileMimeType,
-              file.fileSize,
-              (fileName, fileMimeType) =>
-                fileMimeType match {
-                  case _ =>
-                    HeaderNames.CONTENT_DISPOSITION ->
-                      s"""inline; filename="${fileName.filter(_.toInt < 128)}"; filename*=utf-8''${RFC3986Encoder
-                        .encode(fileName)}"""
-                }
-            )
-
-          case _ => Future.successful(NotFound)
-        }
-      case _ => Future.successful(NotFound)
-
-    }
+class Renderer @Inject() (router: Router) {
 
   final def acknowledgeFileUploadRedirect = resultOf { case state =>
     (state match {
@@ -148,10 +46,6 @@ class Renderer @Inject() (
     (stateAndBreadcrumbs: (State, List[State])) =>
       f.applyOrElse(stateAndBreadcrumbs._1, (_: State) => play.api.mvc.Results.NotImplemented)
 
-  private def asyncResultOf(
-    f: PartialFunction[State, Future[Result]]
-  ): State => Future[Result] = { (state: State) =>
-    f(state)
-  }
+  def asyncResultOf(f: PartialFunction[State, Future[Result]]): State => Future[Result] = f(_)
 
 }

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/Renderer.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/Renderer.scala
@@ -48,7 +48,7 @@ class Renderer @Inject() (
   final def display(state: State, breadcrumbs: List[State], formWithErrors: Option[Form[_]])(implicit
     request: Request[_],
     m: Messages
-  ): Result = {
+  ): Result =
     state match {
       case State.Uninitialized =>
         Redirect(appConfig.govukStartUrl)
@@ -66,55 +66,6 @@ class Renderer @Inject() (
           Redirect(context.config.getContinueWhenFullUrl)
         else
           Redirect(context.config.continueUrl)
-
-      case State.UploadMultipleFiles(context, fileUploads) =>
-        Ok(
-          views.uploadMultipleFilesView(
-            minimumNumberOfFiles = context.config.minimumNumberOfFiles,
-            maximumNumberOfFiles = context.config.maximumNumberOfFiles,
-            initialNumberOfEmptyRows = context.config.initialNumberOfEmptyRows,
-            maximumFileSizeBytes = context.config.maximumFileSizeBytes,
-            filePickerAcceptFilter = context.config.getFilePickerAcceptFilter,
-            allowedFileTypesHint = context.config.content.allowedFilesTypesHint
-              .orElse(context.config.allowedFileExtensions)
-              .getOrElse(context.config.allowedContentTypes),
-            context.config.newFileDescription,
-            initialFileUploads = fileUploads.files,
-            initiateNextFileUpload = router.initiateNextFileUpload,
-            checkFileVerificationStatus = router.checkFileVerificationStatus,
-            removeFile = router.removeFileUploadByReferenceAsync,
-            previewFile = router.previewFileUploadByReference,
-            markFileRejected = router.markFileUploadAsRejectedAsync,
-            continueAction =
-              if (context.config.features.showYesNoQuestionBeforeContinue)
-                router.continueWithYesNo
-              else router.continueToHost,
-            backLink = Call("GET", context.config.backlinkUrl),
-            context.config.features.showYesNoQuestionBeforeContinue,
-            context.config.content.yesNoQuestionText,
-            formWithErrors.or(YesNoChoiceForm)
-          )(implicitly[Request[_]], context.messages, context.config.features, context.config.content)
-        )
-
-      case State.UploadSingleFile(context, reference, uploadRequest, fileUploads, maybeUploadError) =>
-        Ok(
-          views.uploadSingleFileView(
-            maxFileUploadsNumber = context.config.maximumNumberOfFiles,
-            maximumFileSizeBytes = context.config.maximumFileSizeBytes,
-            filePickerAcceptFilter = context.config.getFilePickerAcceptFilter,
-            allowedFileTypesHint = context.config.content.allowedFilesTypesHint
-              .orElse(context.config.allowedFileExtensions)
-              .getOrElse(context.config.allowedContentTypes),
-            context.config.newFileDescription,
-            uploadRequest = uploadRequest,
-            fileUploads = fileUploads,
-            maybeUploadError = maybeUploadError,
-            successAction = router.showSummary,
-            failureAction = router.showChooseSingleFile,
-            checkStatusAction = router.checkFileVerificationStatus(reference),
-            backLink = backlink(breadcrumbs)
-          )(implicitly[Request[_]], context.messages, context.config.features, context.config.content)
-        )
 
       case State.WaitingForFileVerification(context, reference, _, _, _) =>
         Ok(
@@ -152,7 +103,6 @@ class Renderer @Inject() (
 
       case _ => NotImplemented
     }
-  }
 
   final def renderUploadRequestJson(
     uploadId: String
@@ -258,7 +208,7 @@ class Renderer @Inject() (
     }).withHeaders(HeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN -> "*")
   }
 
-  private def backlink(breadcrumbs: List[State]): Call =
+  def backlink(breadcrumbs: List[State]): Call =
     breadcrumbs.headOption
       .map(router.routeTo)
       .getOrElse(router.routeTo(State.Uninitialized))

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/Router.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/Router.scala
@@ -27,25 +27,6 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class Router @Inject() (appConfig: AppConfig) {
 
-  final val start = routes.StartController.start
-  final val continueToHost = routes.ContinueToHostController.continueToHost
-  final val continueWithYesNo = routes.ContinueToHostController.continueWithYesNo
-  final val showChooseMultipleFiles = routes.ChooseMultipleFilesController.showChooseMultipleFiles
-  final val showChooseSingleFile = routes.ChooseSingleFileController.showChooseFile
-  final val showSummary = routes.SummaryController.showSummary
-  final val submitUploadAnotherFileChoice = routes.SummaryController.submitUploadAnotherFileChoice
-  final val showWaitingForFileVerification = routes.FileVerificationController.showWaitingForFileVerification
-  final val checkFileVerificationStatus = routes.FileVerificationController.checkFileVerificationStatus _
-  final val markFileUploadAsRejected = routes.FileRejectedController.markFileUploadAsRejected
-  final val markFileUploadAsRejectedAsync = routes.FileRejectedController.markFileUploadAsRejectedAsync
-  final val asyncMarkFileUploadAsPosted = routes.FilePostedController.asyncMarkFileUploadAsPosted _
-  final val asyncMarkFileUploadAsRejected = routes.FileRejectedController.asyncMarkFileUploadAsRejected _
-  final val asyncWaitingForFileVerification = routes.FileVerificationController.asyncWaitingForFileVerification _
-  final val removeFileUploadByReference = routes.RemoveController.removeFileUploadByReference _
-  final val removeFileUploadByReferenceAsync = routes.RemoveController.removeFileUploadByReferenceAsync _
-  final val initiateNextFileUpload = routes.InitiateUpscanController.initiateNextFileUpload _
-  final val previewFileUploadByReference = routes.PreviewController.previewFileUploadByReference _
-
   /** This cookie is set by the script on each request coming from one of our own pages open in the browser.
     */
   final val COOKIE_JSENABLED = "jsenabled"
@@ -62,7 +43,7 @@ class Router @Inject() (appConfig: AppConfig) {
     Redirect(
       stateAndBreadcrumbsOpt
         .map { case (s, _) => routeTo(s) }
-        .getOrElse(start)
+        .getOrElse(routes.StartController.start)
     )
       .flashing(Flash {
         val data = formWithErrors.data
@@ -79,13 +60,13 @@ class Router @Inject() (appConfig: AppConfig) {
             .getOrElse(context.config.backlinkUrl)
         )
 
-      case State.ContinueToHost(context, fileUploads) => continueToHost
-      case _: State.UploadMultipleFiles               => showChooseMultipleFiles
-      case _: State.UploadSingleFile                  => showChooseSingleFile
-      case _: State.WaitingForFileVerification        => showWaitingForFileVerification
-      case _: State.Summary                           => showSummary
-      case _: State.SwitchToUploadSingleFile          => showChooseSingleFile
-      case _                                          => Call("GET", appConfig.govukStartUrl)
+      case State.ContinueToHost(context, fileUploads) => routes.ContinueToHostController.continueToHost
+      case _: State.UploadMultipleFiles               => routes.ChooseMultipleFilesController.showChooseMultipleFiles
+      case _: State.UploadSingleFile                  => routes.ChooseSingleFileController.showChooseFile
+      case _: State.WaitingForFileVerification => routes.FileVerificationController.showWaitingForFileVerification
+      case _: State.Summary                    => routes.SummaryController.showSummary
+      case _: State.SwitchToUploadSingleFile   => routes.ChooseSingleFileController.showChooseFile
+      case _                                   => Call("GET", appConfig.govukStartUrl)
     }
 
   final def callbackFromUpscan(journeyId: String, nonce: String) =
@@ -94,17 +75,17 @@ class Router @Inject() (appConfig: AppConfig) {
 
   final def successRedirect(journeyId: String)(implicit rh: RequestHeader): String =
     appConfig.baseExternalCallbackUrl + (rh.cookies.get(COOKIE_JSENABLED) match {
-      case Some(_) => asyncWaitingForFileVerification(journeyId)
-      case None    => showWaitingForFileVerification
+      case Some(_) => routes.FileVerificationController.asyncWaitingForFileVerification(journeyId)
+      case None    => routes.FileVerificationController.showWaitingForFileVerification
     })
 
   final def successRedirectWhenUploadingMultipleFiles(journeyId: String): String =
-    appConfig.baseExternalCallbackUrl + asyncMarkFileUploadAsPosted(journeyId)
+    appConfig.baseExternalCallbackUrl + routes.FilePostedController.asyncMarkFileUploadAsPosted(journeyId)
 
   final def errorRedirect(journeyId: String)(implicit rh: RequestHeader): String =
     appConfig.baseExternalCallbackUrl + (rh.cookies.get(COOKIE_JSENABLED) match {
-      case Some(_) => asyncMarkFileUploadAsRejected(journeyId)
-      case None    => markFileUploadAsRejected
+      case Some(_) => routes.FileRejectedController.asyncMarkFileUploadAsRejected(journeyId)
+      case None    => routes.FileRejectedController.markFileUploadAsRejected
     })
 
 }

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/StartController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/StartController.scala
@@ -34,9 +34,9 @@ class StartController @Inject() (
   final val start: Action[AnyContent] =
     Action { implicit request =>
       if (router.preferUploadMultipleFiles)
-        Redirect(router.showChooseMultipleFiles)
+        Redirect(routes.ChooseMultipleFilesController.showChooseMultipleFiles)
       else
-        Ok(views.startView(router.showChooseMultipleFiles))
+        Ok(views.startView(routes.ChooseMultipleFilesController.showChooseMultipleFiles))
     }
 
 }

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/SummaryController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/SummaryController.scala
@@ -71,21 +71,21 @@ class SummaryController @Inject() (
       view(
         maxFileUploadsNumber = context.config.maximumNumberOfFiles,
         maximumFileSizeBytes = context.config.maximumFileSizeBytes,
-        form,
-        fileUploads,
-        router.submitUploadAnotherFileChoice,
-        router.previewFileUploadByReference,
-        router.removeFileUploadByReference,
-        renderer.backlink(breadcrumbs)
+        form = form,
+        fileUploads = fileUploads,
+        postAction = routes.SummaryController.submitUploadAnotherFileChoice,
+        previewFileCall = routes.PreviewController.previewFileUploadByReference,
+        removeFileCall = routes.RemoveController.removeFileUploadByReference,
+        backLink = renderer.backlink(breadcrumbs)
       )(implicitly[Request[_]], context.messages, context.config.features, context.config.content)
     else
       viewNoChoice(
-        context.config.maximumNumberOfFiles,
-        fileUploads,
-        router.continueToHost,
-        router.previewFileUploadByReference,
-        router.removeFileUploadByReference,
-        Call("GET", context.config.backlinkUrl)
+        maxFileUploadsNumber = context.config.maximumNumberOfFiles,
+        fileUploads = fileUploads,
+        postAction = routes.ContinueToHostController.continueToHost,
+        previewFileCall = routes.PreviewController.previewFileUploadByReference,
+        removeFileCall = routes.RemoveController.removeFileUploadByReference,
+        backLink = Call("GET", context.config.backlinkUrl)
       )(implicitly[Request[_]], context.messages, context.config.features, context.config.content)
 
   // POST /summary

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/internal/InitializeController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/internal/InitializeController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.uploaddocuments.controllers.internal
 import play.api.libs.json.JsValue
 import play.api.mvc.Action
 import play.mvc.Http.HeaderNames
-import uk.gov.hmrc.uploaddocuments.controllers.{BaseController, BaseControllerComponents, Renderer, Router, routes => mainRoutes}
+import uk.gov.hmrc.uploaddocuments.controllers.{BaseController, BaseControllerComponents, Renderer, routes => mainRoutes}
 import uk.gov.hmrc.uploaddocuments.journeys.{JourneyModel, State}
 import uk.gov.hmrc.uploaddocuments.models._
 import uk.gov.hmrc.uploaddocuments.repository.NewJourneyCacheRepository
@@ -33,7 +33,6 @@ import scala.concurrent.ExecutionContext
 class InitializeController @Inject() (
   sessionStateService: SessionStateService,
   renderer: Renderer,
-  router: Router,
   components: BaseControllerComponents,
   newJourneyCacheRepository: NewJourneyCacheRepository
 )(implicit ec: ExecutionContext)
@@ -66,7 +65,7 @@ class InitializeController @Inject() (
           HeaderNames.LOCATION ->
             (
               if (!context.config.features.showUploadMultiple)
-                router.showChooseSingleFile
+                mainRoutes.ChooseSingleFileController.showChooseFile
               else
                 mainRoutes.StartController.start
             ).url

--- a/app/uk/gov/hmrc/uploaddocuments/repository/NewJourneyCacheRepository.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/repository/NewJourneyCacheRepository.scala
@@ -39,7 +39,7 @@ class NewJourneyCacheRepository @Inject() (
 
 object NewJourneyCacheRepository {
   object DataKeys {
-    val journeyConfigDataKey = DataKey[FileUploadContext]("journeyConfig")
+    val journeyContextDataKey = DataKey[FileUploadContext]("journeyConfig")
     val uploadedFiles = DataKey[FileUploads]("uploadedFiles")
   }
 }

--- a/app/uk/gov/hmrc/uploaddocuments/repository/NewJourneyCacheRepository.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/repository/NewJourneyCacheRepository.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.uploaddocuments.repository
 
 import uk.gov.hmrc.mongo.cache.{CacheItem, DataKey}
 import uk.gov.hmrc.mongo.{MongoComponent, TimestampSupport}
-import uk.gov.hmrc.uploaddocuments.models.FileUploadInitializationRequest
+import uk.gov.hmrc.uploaddocuments.models.{FileUploadContext, FileUploadInitializationRequest, FileUploads}
 import uk.gov.hmrc.uploaddocuments.wiring.AppConfig
 
 import javax.inject.{Inject, Singleton}
@@ -35,13 +35,11 @@ class NewJourneyCacheRepository @Inject() (
       collectionName = "upload-customs-documents-journeys",
       ttl = appConfig.mongoSessionExpiration,
       timestampSupport = timestampSupport
-    ) {
+    )
 
-  val journeyConfigDataKey = DataKey[FileUploadInitializationRequest]("journeyConfig")
-
-  def storeJourneyConfig(id: String)(data: FileUploadInitializationRequest): Future[CacheItem] =
-    put(id)(journeyConfigDataKey, data)
-
-  def getJourneyConfig(id: String): Future[Option[FileUploadInitializationRequest]] =
-    get[FileUploadInitializationRequest](id)(journeyConfigDataKey)
+object NewJourneyCacheRepository {
+  object DataKeys {
+    val journeyConfigDataKey = DataKey[FileUploadContext]("journeyConfig")
+    val uploadedFiles = DataKey[FileUploads]("uploadedFiles")
+  }
 }

--- a/app/uk/gov/hmrc/uploaddocuments/repository/NewJourneyCacheRepository.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/repository/NewJourneyCacheRepository.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.uploaddocuments.repository
+
+import uk.gov.hmrc.mongo.cache.{CacheItem, DataKey}
+import uk.gov.hmrc.mongo.{MongoComponent, TimestampSupport}
+import uk.gov.hmrc.uploaddocuments.models.FileUploadInitializationRequest
+import uk.gov.hmrc.uploaddocuments.wiring.AppConfig
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class NewJourneyCacheRepository @Inject() (
+  mongoComponent: MongoComponent,
+  timestampSupport: TimestampSupport,
+  appConfig: AppConfig
+)(implicit ec: ExecutionContext)
+    extends CacheRepository(
+      mongoComponent = mongoComponent,
+      collectionName = "upload-customs-documents-journeys",
+      ttl = appConfig.mongoSessionExpiration,
+      timestampSupport = timestampSupport
+    ) {
+
+  val journeyConfigDataKey = DataKey[FileUploadInitializationRequest]("journeyConfig")
+
+  def storeJourneyConfig(id: String)(data: FileUploadInitializationRequest): Future[CacheItem] =
+    put(id)(journeyConfigDataKey, data)
+
+  def getJourneyConfig(id: String): Future[Option[FileUploadInitializationRequest]] =
+    get[FileUploadInitializationRequest](id)(journeyConfigDataKey)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file("."))
     name := "upload-customs-documents-frontend",
     organization := "uk.gov.hmrc",
     scalaVersion := "2.12.15",
-    PlayKeys.playDefaultPort := 10100,
+    PlayKeys.playDefaultPort := 10110,
     TwirlKeys.templateImports ++= Seq(
       "play.twirl.api.HtmlFormat",
       "uk.gov.hmrc.govukfrontend.views.html.components._",

--- a/it/uk/gov/hmrc/uploaddocuments/controllers/ContinueToHostControllerISpec.scala
+++ b/it/uk/gov/hmrc/uploaddocuments/controllers/ContinueToHostControllerISpec.scala
@@ -2,6 +2,7 @@ package uk.gov.hmrc.uploaddocuments.controllers
 
 import uk.gov.hmrc.uploaddocuments.journeys.State
 import uk.gov.hmrc.uploaddocuments.models._
+import uk.gov.hmrc.uploaddocuments.repository.NewJourneyCacheRepository.DataKeys
 import uk.gov.hmrc.uploaddocuments.stubs.ExternalApiStubs
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -23,6 +24,10 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
           context,
           fileUploads = nonEmptyFileUploads
         )
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.uploadedFiles, nonEmptyFileUploads))
+
         sessionStateService.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url")
@@ -46,7 +51,11 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
             )
         )
         val state = State.ContinueToHost(context, fileUploads = FileUploads())
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.uploadedFiles, FileUploads()))
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url")
 
@@ -67,6 +76,9 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
             )
         )
         val state = State.ContinueToHost(context, fileUploads = FileUploads())
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.uploadedFiles, FileUploads()))
         sessionStateService.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url-if-empty")
@@ -87,6 +99,14 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
             )
         )
         val state = State.ContinueToHost(context, fileUploads = nFileUploads(context.config.maximumNumberOfFiles))
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(
+          newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(
+            DataKeys.uploadedFiles,
+            nFileUploads(context.config.maximumNumberOfFiles)
+          )
+        )
         sessionStateService.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url")
@@ -111,7 +131,16 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
             )
         )
         val state = State.ContinueToHost(context, fileUploads = nFileUploads(context.config.maximumNumberOfFiles))
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(
+          newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(
+            DataKeys.uploadedFiles,
+            nFileUploads(context.config.maximumNumberOfFiles)
+          )
+        )
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url-if-full")
 
@@ -140,7 +169,11 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
           context,
           fileUploads = nonEmptyFileUploads
         )
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.uploadedFiles, nonEmptyFileUploads))
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url")
 
@@ -163,7 +196,11 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
             )
         )
         val state = State.ContinueToHost(context, fileUploads = FileUploads())
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.uploadedFiles, FileUploads()))
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url")
 
@@ -184,7 +221,11 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
             )
         )
         val state = State.ContinueToHost(context, fileUploads = FileUploads())
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.uploadedFiles, FileUploads()))
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url-if-empty")
 
@@ -204,7 +245,16 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
             )
         )
         val state = State.ContinueToHost(context, fileUploads = nFileUploads(context.config.maximumNumberOfFiles))
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(
+          newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(
+            DataKeys.uploadedFiles,
+            nFileUploads(context.config.maximumNumberOfFiles)
+          )
+        )
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url")
 
@@ -228,7 +278,16 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
             )
         )
         val state = State.ContinueToHost(context, fileUploads = nFileUploads(context.config.maximumNumberOfFiles))
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(
+          newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(
+            DataKeys.uploadedFiles,
+            nFileUploads(context.config.maximumNumberOfFiles)
+          )
+        )
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url-if-full")
 
@@ -255,7 +314,11 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
           context,
           fileUploads = nonEmptyFileUploads
         )
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.uploadedFiles, nonEmptyFileUploads))
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/backlink-url")
 
@@ -278,7 +341,11 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
             )
         )
         val state = State.ContinueToHost(context, fileUploads = FileUploads())
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.uploadedFiles, FileUploads()))
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/backlink-url")
 
@@ -299,7 +366,11 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
             )
         )
         val state = State.ContinueToHost(context, fileUploads = FileUploads())
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.uploadedFiles, FileUploads()))
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/backlink-url")
 
@@ -319,7 +390,16 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
             )
         )
         val state = State.ContinueToHost(context, fileUploads = nFileUploads(context.config.maximumNumberOfFiles))
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(
+          newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(
+            DataKeys.uploadedFiles,
+            nFileUploads(context.config.maximumNumberOfFiles)
+          )
+        )
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/backlink-url")
 
@@ -343,7 +423,16 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
             )
         )
         val state = State.ContinueToHost(context, fileUploads = nFileUploads(context.config.maximumNumberOfFiles))
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(
+          newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(
+            DataKeys.uploadedFiles,
+            nFileUploads(context.config.maximumNumberOfFiles)
+          )
+        )
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/backlink-url")
 
@@ -371,7 +460,11 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
           context,
           fileUploads = nonEmptyFileUploads
         )
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.uploadedFiles, nonEmptyFileUploads))
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url-if-yes")
 
@@ -395,7 +488,11 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
             )
         )
         val state = State.ContinueToHost(context, fileUploads = FileUploads())
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.uploadedFiles, FileUploads()))
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url-if-yes")
 
@@ -417,7 +514,11 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
             )
         )
         val state = State.ContinueToHost(context, fileUploads = FileUploads())
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.uploadedFiles, FileUploads()))
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url-if-yes")
 
@@ -438,7 +539,16 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
             )
         )
         val state = State.ContinueToHost(context, fileUploads = nFileUploads(context.config.maximumNumberOfFiles))
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(
+          newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(
+            DataKeys.uploadedFiles,
+            nFileUploads(context.config.maximumNumberOfFiles)
+          )
+        )
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url-if-yes")
 
@@ -463,7 +573,16 @@ class ContinueToHostControllerISpec extends ControllerISpecBase with ExternalApi
             )
         )
         val state = State.ContinueToHost(context, fileUploads = nFileUploads(context.config.maximumNumberOfFiles))
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(
+          newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(
+            DataKeys.uploadedFiles,
+            nFileUploads(context.config.maximumNumberOfFiles)
+          )
+        )
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url-if-yes")
 

--- a/it/uk/gov/hmrc/uploaddocuments/controllers/ControllerISpecBase.scala
+++ b/it/uk/gov/hmrc/uploaddocuments/controllers/ControllerISpecBase.scala
@@ -9,7 +9,7 @@ import uk.gov.hmrc.crypto.PlainText
 import uk.gov.hmrc.http.{HeaderCarrier, SessionId, SessionKeys}
 import uk.gov.hmrc.uploaddocuments.journeys.State
 import uk.gov.hmrc.uploaddocuments.models._
-import uk.gov.hmrc.uploaddocuments.repository.CacheRepository
+import uk.gov.hmrc.uploaddocuments.repository.{CacheRepository, NewJourneyCacheRepository}
 import uk.gov.hmrc.uploaddocuments.services.{EncryptedSessionCache, KeyProvider, SessionStateService}
 import uk.gov.hmrc.uploaddocuments.support.{SHA256, ServerISpec, StateMatchers, TestData, TestSessionStateService}
 
@@ -20,6 +20,8 @@ trait ControllerISpecBase extends ServerISpec with StateMatchers {
   val journeyId = "sadasdjkasdhuqyhwa326176318346674e764764"
 
   implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId(journeyId)))
+
+  lazy val newJourneyRepo = app.injector.instanceOf[NewJourneyCacheRepository]
 
   import play.api.i18n._
   implicit val messages: Messages = MessagesImpl(Lang("en"), app.injector.instanceOf[MessagesApi])

--- a/it/uk/gov/hmrc/uploaddocuments/controllers/SummaryControllerISpec.scala
+++ b/it/uk/gov/hmrc/uploaddocuments/controllers/SummaryControllerISpec.scala
@@ -2,6 +2,7 @@ package uk.gov.hmrc.uploaddocuments.controllers
 
 import uk.gov.hmrc.uploaddocuments.journeys.State
 import uk.gov.hmrc.uploaddocuments.models._
+import uk.gov.hmrc.uploaddocuments.repository.NewJourneyCacheRepository.DataKeys
 import uk.gov.hmrc.uploaddocuments.stubs.UpscanInitiateStubs
 import uk.gov.hmrc.uploaddocuments.support.SHA256
 
@@ -181,12 +182,14 @@ class SummaryControllerISpec extends ControllerISpecBase with UpscanInitiateStub
 
       "redirect to the continue_url when yes and files number limit has been reached" in {
 
+        val context = FileUploadContext(fileUploadSessionConfig)
         val fileUploads = nFileUploads(FILES_LIMIT)
-        val state = State.Summary(
-          FileUploadContext(fileUploadSessionConfig),
-          fileUploads
-        )
+        val state = State.Summary(context, fileUploads)
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.uploadedFiles, fileUploads))
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url")
 
@@ -203,12 +206,14 @@ class SummaryControllerISpec extends ControllerISpecBase with UpscanInitiateStub
 
       "redirect to the continue_url when no and files number below the limit" in {
 
+        val context = FileUploadContext(fileUploadSessionConfig)
         val fileUploads = FileUploads(files = for (i <- 1 until FILES_LIMIT) yield TestData.acceptedFileUpload)
-        val state = State.Summary(
-          FileUploadContext(fileUploadSessionConfig),
-          fileUploads
-        )
+        val state = State.Summary(context, fileUploads)
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.uploadedFiles, fileUploads))
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url")
 
@@ -224,12 +229,14 @@ class SummaryControllerISpec extends ControllerISpecBase with UpscanInitiateStub
       }
 
       "redirect to the continue_url when no and files number above the limit" in {
+        val context = FileUploadContext(fileUploadSessionConfig)
         val fileUploads = nFileUploads(FILES_LIMIT)
-        val state = State.Summary(
-          FileUploadContext(fileUploadSessionConfig),
-          fileUploads
-        )
+        val state = State.Summary(context, fileUploads)
+
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey, context))
+        await(newJourneyRepo.put(sessionStateService.getJourneyId(hc).get)(DataKeys.uploadedFiles, fileUploads))
         sessionStateService.setState(state)
+
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val expected = givenSomePage(200, "/continue-url")
 

--- a/it/uk/gov/hmrc/uploaddocuments/controllers/internal/InitializeControllerISpec.scala
+++ b/it/uk/gov/hmrc/uploaddocuments/controllers/internal/InitializeControllerISpec.scala
@@ -4,6 +4,7 @@ import play.api.libs.json.{JsString, Json}
 import uk.gov.hmrc.uploaddocuments.controllers.ControllerISpecBase
 import uk.gov.hmrc.uploaddocuments.journeys.State
 import uk.gov.hmrc.uploaddocuments.models._
+import uk.gov.hmrc.uploaddocuments.repository.NewJourneyCacheRepository.DataKeys
 
 import java.time.ZonedDateTime
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -68,8 +69,17 @@ class InitializeControllerISpec extends ControllerISpecBase {
           FileUploads()
         )
 
-        await(newJourneyRepo.getJourneyConfig(sessionStateService.getJourneyId(hc).get)) shouldBe Some(
-          FileUploadInitializationRequest(fileUploadSessionConfig, Seq.empty)
+        await(
+          newJourneyRepo.get(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyConfigDataKey)
+        ) shouldBe Some(
+          FileUploadContext(
+            fileUploadSessionConfig,
+            HostService.Any
+          )
+        )
+
+        await(newJourneyRepo.get(sessionStateService.getJourneyId(hc).get)(DataKeys.uploadedFiles)) shouldBe Some(
+          FileUploads()
         )
       }
 
@@ -108,8 +118,17 @@ class InitializeControllerISpec extends ControllerISpecBase {
           FileUploads(preexistingUploads.map(_.toFileUpload))
         )
 
-        await(newJourneyRepo.getJourneyConfig(sessionStateService.getJourneyId(hc).get)) shouldBe Some(
-          FileUploadInitializationRequest(fileUploadSessionConfig, preexistingUploads)
+        await(
+          newJourneyRepo.get(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyConfigDataKey)
+        ) shouldBe Some(
+          FileUploadContext(
+            fileUploadSessionConfig,
+            HostService.Any
+          )
+        )
+
+        await(newJourneyRepo.get(sessionStateService.getJourneyId(hc).get)(DataKeys.uploadedFiles)) shouldBe Some(
+          FileUploads(preexistingUploads.map(_.toFileUpload))
         )
       }
     }

--- a/it/uk/gov/hmrc/uploaddocuments/controllers/internal/InitializeControllerISpec.scala
+++ b/it/uk/gov/hmrc/uploaddocuments/controllers/internal/InitializeControllerISpec.scala
@@ -67,6 +67,10 @@ class InitializeControllerISpec extends ControllerISpecBase {
           ),
           FileUploads()
         )
+
+        await(newJourneyRepo.getJourneyConfig(sessionStateService.getJourneyId(hc).get)) shouldBe Some(
+          FileUploadInitializationRequest(fileUploadSessionConfig, Seq.empty)
+        )
       }
 
       "register config and pre-existing file uploads" in {
@@ -102,6 +106,10 @@ class InitializeControllerISpec extends ControllerISpecBase {
             HostService.Any
           ),
           FileUploads(preexistingUploads.map(_.toFileUpload))
+        )
+
+        await(newJourneyRepo.getJourneyConfig(sessionStateService.getJourneyId(hc).get)) shouldBe Some(
+          FileUploadInitializationRequest(fileUploadSessionConfig, preexistingUploads)
         )
       }
     }

--- a/it/uk/gov/hmrc/uploaddocuments/controllers/internal/InitializeControllerISpec.scala
+++ b/it/uk/gov/hmrc/uploaddocuments/controllers/internal/InitializeControllerISpec.scala
@@ -70,7 +70,7 @@ class InitializeControllerISpec extends ControllerISpecBase {
         )
 
         await(
-          newJourneyRepo.get(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyConfigDataKey)
+          newJourneyRepo.get(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey)
         ) shouldBe Some(
           FileUploadContext(
             fileUploadSessionConfig,
@@ -119,7 +119,7 @@ class InitializeControllerISpec extends ControllerISpecBase {
         )
 
         await(
-          newJourneyRepo.get(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyConfigDataKey)
+          newJourneyRepo.get(sessionStateService.getJourneyId(hc).get)(DataKeys.journeyContextDataKey)
         ) shouldBe Some(
           FileUploadContext(
             fileUploadSessionConfig,

--- a/it/uk/gov/hmrc/uploaddocuments/repositories/NewJourneyCacheRepositoryISpec.scala
+++ b/it/uk/gov/hmrc/uploaddocuments/repositories/NewJourneyCacheRepositoryISpec.scala
@@ -26,7 +26,9 @@ class NewJourneyCacheRepositoryISpec extends UnitSpec {
   "DataKeys" must {
 
     "have the correct key and model type" in {
-      NewJourneyCacheRepository.DataKeys.journeyConfigDataKey shouldBe DataKey[FileUploadSessionConfig]("journeyConfig")
+      NewJourneyCacheRepository.DataKeys.journeyContextDataKey shouldBe DataKey[FileUploadSessionConfig](
+        "journeyConfig"
+      )
       NewJourneyCacheRepository.DataKeys.uploadedFiles shouldBe DataKey[FileUploads]("uploadedFiles")
     }
   }

--- a/it/uk/gov/hmrc/uploaddocuments/repositories/NewJourneyCacheRepositoryISpec.scala
+++ b/it/uk/gov/hmrc/uploaddocuments/repositories/NewJourneyCacheRepositoryISpec.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.uploaddocuments.repositories
+
+import uk.gov.hmrc.mongo.cache.DataKey
+import uk.gov.hmrc.uploaddocuments.models.{FileUploadInitializationRequest, FileUploadSessionConfig, Nonce}
+import uk.gov.hmrc.uploaddocuments.repository.NewJourneyCacheRepository
+import uk.gov.hmrc.uploaddocuments.support.{BaseISpec, MongoHelpers}
+
+class NewJourneyCacheRepositoryISpec extends BaseISpec with MongoHelpers {
+
+  lazy val app = appBuilder.build()
+
+  lazy val repo: NewJourneyCacheRepository = app.injector.instanceOf[NewJourneyCacheRepository]
+
+  val journeyId = "foo"
+
+  val dummyConfig = FileUploadSessionConfig(
+    Nonce.toNonce(12345),
+    "continueUrl",
+    "backlinkUrl",
+    "callbackUrl"
+  )
+  val dummyRequest = FileUploadInitializationRequest(
+    dummyConfig,
+    Seq()
+  )
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    removeAll(repo)
+    await(repo.collection.countDocuments().toFuture()) shouldBe 0
+  }
+
+  ".journeyConfigDataKey" must {
+
+    "have the correct key and model type" in {
+      repo.journeyConfigDataKey shouldBe DataKey[FileUploadInitializationRequest]("journeyConfig")
+    }
+  }
+
+  ".storeJourneyConfig(id: String)(data: FileUploadInitializationRequest)" when {
+
+    "no record exists" must {
+
+      "upsert the first" in {
+
+        await(repo.storeJourneyConfig(journeyId)(dummyRequest))
+        await(repo.collection.countDocuments().toFuture()) shouldBe 1
+
+        await(repo.get[FileUploadInitializationRequest](journeyId)(repo.journeyConfigDataKey)) shouldBe Some(
+          dummyRequest
+        )
+      }
+    }
+
+    "record already exists" must {
+
+      "update existing" in {
+
+        await(repo.storeJourneyConfig(journeyId)(dummyRequest))
+        await(repo.collection.countDocuments().toFuture()) shouldBe 1
+
+        val updatedModel = dummyRequest.copy(config = dummyConfig.copy(initialNumberOfEmptyRows = 10))
+
+        await(repo.storeJourneyConfig(journeyId)(updatedModel))
+        await(repo.collection.countDocuments().toFuture()) shouldBe 1
+
+        await(repo.get[FileUploadInitializationRequest](journeyId)(repo.journeyConfigDataKey)) shouldBe Some(
+          updatedModel
+        )
+      }
+    }
+  }
+
+  ".getJourneyConfig(id: String)" when {
+
+    "record exists" must {
+
+      "return the journey config" in {
+
+        await(repo.storeJourneyConfig(journeyId)(dummyRequest))
+        await(repo.collection.countDocuments().toFuture()) shouldBe 1
+
+        await(repo.getJourneyConfig(journeyId)) shouldBe Some(dummyRequest)
+      }
+    }
+
+    "record does not exist" must {
+
+      "return None" in {
+        await(repo.getJourneyConfig(journeyId)) shouldBe None
+      }
+    }
+  }
+}

--- a/it/uk/gov/hmrc/uploaddocuments/support/MongoHelpers.scala
+++ b/it/uk/gov/hmrc/uploaddocuments/support/MongoHelpers.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.uploaddocuments.support
+
+import org.mongodb.scala.bson.BsonDocument
+import org.mongodb.scala.result.{DeleteResult, InsertOneResult}
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+
+import scala.reflect.ClassTag
+
+trait MongoHelpers { _: UnitSpec =>
+
+  def count[A](repo: => PlayMongoRepository[A]): Long =
+    await(repo.collection.countDocuments().toFuture())
+
+  def removeAll[A](repo: => PlayMongoRepository[A]): DeleteResult =
+    await(repo.collection.deleteMany(BsonDocument()).toFuture())
+
+  def insert[A](repo: => PlayMongoRepository[A], model: A): InsertOneResult =
+    await(repo.collection.insertOne(model).toFuture())
+
+  def findAll[A](repo: => PlayMongoRepository[A])(implicit classTag: ClassTag[A]): Seq[A] =
+    await(repo.collection.find().toFuture())
+}


### PR DESCRIPTION
#2 should be reviewed and merged prior to this.

This PR moves all the view rendering from the 'Renderer' class and places it within the controllers. It also starts to add in functionality to retrieve the journeyConfig from the new store instead of from the current encrypted session store.

The file upload data is still managed through the encrypted session store. The next PR will start to look at managing the state of the file uploads within the new mongo collection which should allow us to move away from the encrypted session store fully.