### PR TITLE
[refactorControllersToRemoveServicesInComponents] Inject services needed into controllers directly rather than via components

### DIFF
--- a/app/uk/gov/hmrc/uploaddocuments/controllers/FilePostedController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/FilePostedController.scala
@@ -32,25 +32,25 @@ class FilePostedController @Inject()(components: BaseControllerComponents,
                                     (implicit ec: ExecutionContext) extends BaseController(components) with LoggerUtil {
 
   // GET /journey/:journeyId/file-posted
-  final def asyncMarkFileUploadAsPosted(implicit journeyId: JourneyId): Action[AnyContent] =
-    Action.async { implicit request =>
-      Forms.UpscanUploadSuccessForm
-        .bindFromRequest
-        .fold(
-          formWithErrors =>
-            Future.successful(Redirect(routes.ChooseMultipleFilesController.showChooseMultipleFiles).withFormError(formWithErrors))
-          ,
-          s3UploadSuccess =>
-            fileUploadService.markFileAsPosted(s3UploadSuccess.key).map { _ =>
-              Created.withHeaders(HeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN -> "*")
-            }
-        )
-    }
+  final def asyncMarkFileUploadAsPosted(implicit journeyId: JourneyId): Action[AnyContent] = Action.async { implicit request =>
+    Forms.UpscanUploadSuccessForm
+      .bindFromRequest
+      .fold(
+        _ => {
+          error("[asyncMarkFileUploadAsPosted] Query Parameters from Upscan could not be bound to form")
+          debug(s"[asyncMarkFileUploadAsPosted] Query Params Received: ${request.queryString}")
+          Future.successful(BadRequest)
+        },
+        s3UploadSuccess =>
+          fileUploadService.markFileAsPosted(s3UploadSuccess.key).map { _ =>
+            Created.withHeaders(HeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN -> "*")
+          }
+      )
+  }
 
   // OPTIONS /journey/:journeyId/file-posted
-  final def preflightUpload(journeyId: JourneyId): Action[AnyContent] =
-    Action {
-      Created.withHeaders(HeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN -> "*")
-    }
+  final def preflightUpload(journeyId: JourneyId): Action[AnyContent] = Action {
+    Created.withHeaders(HeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN -> "*")
+  }
 
 }

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/FileUploadsControllerHelper.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/FileUploadsControllerHelper.scala
@@ -16,21 +16,18 @@
 
 package uk.gov.hmrc.uploaddocuments.controllers
 
-import play.api.mvc.{Action, AnyContent}
-import uk.gov.hmrc.uploaddocuments.views.html.StartView
+import play.api.mvc.Result
+import uk.gov.hmrc.uploaddocuments.models.{FileUploads, JourneyId}
+import uk.gov.hmrc.uploaddocuments.services.FileUploadService
 
-import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
 
-@Singleton
-class StartController @Inject()(view: StartView,
-                                components: BaseControllerComponents) extends BaseController(components) {
+trait FileUploadsControllerHelper { baseController: BaseController =>
 
-  // GET /
-  final val start: Action[AnyContent] = Action { implicit request =>
-    if (preferUploadMultipleFiles)
-      Redirect(routes.ChooseMultipleFilesController.showChooseMultipleFiles)
-    else
-      Ok(view(routes.ChooseMultipleFilesController.showChooseMultipleFiles))
-  }
+  val fileUploadService: FileUploadService
+
+  def withFileUploads(body: FileUploads => Future[Result])
+                     (implicit ec: ExecutionContext, journeyId: JourneyId): Future[Result] =
+    fileUploadService.withFiles(Future.successful(Redirect(baseController.components.appConfig.govukStartUrl)))(body)
 
 }

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/InitiateUpscanController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/InitiateUpscanController.scala
@@ -19,36 +19,33 @@ package uk.gov.hmrc.uploaddocuments.controllers
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.uploaddocuments.models.UploadRequest
-import uk.gov.hmrc.uploaddocuments.services.InitiateUpscanService
+import uk.gov.hmrc.uploaddocuments.services.{InitiateUpscanService, JourneyContextService}
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class InitiateUpscanController @Inject()(
-  upscanInitiateService: InitiateUpscanService,
-  components: BaseControllerComponents
-)(implicit ec: ExecutionContext)
-    extends BaseController(components) {
+class InitiateUpscanController @Inject()(upscanInitiateService: InitiateUpscanService,
+                                         components: BaseControllerComponents,
+                                         override val journeyContextService: JourneyContextService)
+                                        (implicit ec: ExecutionContext) extends BaseController(components) with JourneyContextControllerHelper {
 
   // POST /initiate-upscan/:uploadId
-  final def initiateNextFileUpload(uploadId: String): Action[AnyContent] =
-    Action.async { implicit request =>
-      whenInSession { implicit journeyId =>
-        whenAuthenticated {
-          withJourneyContext { journeyContext =>
-            upscanInitiateService.initiateNextMultiFileUpload(journeyContext, uploadId).map {
-              case Some(upscanResponse) =>
-                Ok(
-                  Json.obj(
-                    "upscanReference" -> upscanResponse.reference,
-                    "uploadId"        -> uploadId,
-                    "uploadRequest"   -> UploadRequest.formats.writes(upscanResponse.uploadRequest)
-                  ))
-              case None => BadRequest
-            }
+  final def initiateNextFileUpload(uploadId: String): Action[AnyContent] = Action.async { implicit request =>
+    whenInSession { implicit journeyId =>
+      whenAuthenticated {
+        withJourneyContext { implicit journeyContext =>
+          upscanInitiateService.initiateNextMultiFileUpload(uploadId).map {
+            case Some(upscanResponse) =>
+              Ok(Json.obj(fields =
+                "upscanReference" -> upscanResponse.reference,
+                "uploadId"        -> uploadId,
+                "uploadRequest"   -> UploadRequest.formats.writes(upscanResponse.uploadRequest)
+              ))
+            case None => BadRequest
           }
         }
       }
     }
+  }
 }

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/JourneyContextControllerHelper.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/JourneyContextControllerHelper.scala
@@ -16,17 +16,20 @@
 
 package uk.gov.hmrc.uploaddocuments.controllers
 
+import play.api.mvc.Result
+import play.api.mvc.Results.Redirect
+import uk.gov.hmrc.uploaddocuments.models.{FileUploadContext, FileUploads, JourneyId}
+import uk.gov.hmrc.uploaddocuments.services.{FileUploadService, JourneyContextService}
 import uk.gov.hmrc.uploaddocuments.wiring.AppConfig
-import javax.inject.Inject
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
-class SignOutController @Inject()(controllerComponents: MessagesControllerComponents,
-                                  appConfig: AppConfig) extends FrontendController(controllerComponents) {
+import scala.concurrent.{ExecutionContext, Future}
 
-  final def signOut(continueUrl: Option[String]): Action[AnyContent] = Action { _ =>
-    continueUrl.fold(Redirect(appConfig.signOutUrl))(url => Redirect(appConfig.signOutUrl, Map("continue" -> Seq(url))))
-  }
+trait JourneyContextControllerHelper { baseController: BaseController =>
 
-  final def signOutTimeout(continueUrl: Option[String]): Action[AnyContent] = signOut(continueUrl)
+  val journeyContextService: JourneyContextService
+
+  def withJourneyContext(body: FileUploadContext => Future[Result])
+                        (implicit ec: ExecutionContext, journeyId: JourneyId): Future[Result] =
+    journeyContextService.withJourneyContext(Future.successful(Redirect(baseController.components.appConfig.govukStartUrl)))(body)
+
 }

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/LanguageSwitchController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/LanguageSwitchController.scala
@@ -22,21 +22,16 @@ import play.api.i18n.{I18nSupport, Lang, MessagesApi}
 import play.api.mvc._
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
-class LanguageSwitchController @Inject()(
-  appConfig: AppConfig,
-  override implicit val messagesApi: MessagesApi,
-  controllerComponents: MessagesControllerComponents
-) extends FrontendController(controllerComponents) with I18nSupport {
+class LanguageSwitchController @Inject()(appConfig: AppConfig,
+                                         override implicit val messagesApi: MessagesApi,
+                                         controllerComponents: MessagesControllerComponents) extends FrontendController(controllerComponents) with I18nSupport {
 
   private def fallbackURL: String = "/"
-
   private def languageMap: Map[String, Lang] = appConfig.languageMap
 
-  def switchToLanguage(language: String): Action[AnyContent] =
-    Action { implicit request =>
-      val lang = languageMap.getOrElse(language, Lang.defaultLang)
-
-      val redirectURL = request.headers.get(REFERER).getOrElse(fallbackURL)
-      Redirect(redirectURL).withLang(Lang.apply(lang.code))
-    }
+  def switchToLanguage(language: String): Action[AnyContent] = Action { implicit request =>
+    val lang = languageMap.getOrElse(language, Lang.defaultLang)
+    val redirectURL = request.headers.get(REFERER).getOrElse(fallbackURL)
+    Redirect(redirectURL).withLang(Lang.apply(lang.code))
+  }
 }

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/SessionController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/SessionController.scala
@@ -24,8 +24,8 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.Future
 
 @Singleton
-class SessionController @Inject()(controllerComponents: MessagesControllerComponents, timedOutView: TimedOutView)
-    extends FrontendController(controllerComponents) {
+class SessionController @Inject()(controllerComponents: MessagesControllerComponents,
+                                  timedOutView: TimedOutView) extends FrontendController(controllerComponents) {
 
   final val showTimeoutPage: Action[AnyContent] = Action.async { implicit request =>
     Future.successful(Ok(timedOutView()))

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/internal/CallbackFromUpscanController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/internal/CallbackFromUpscanController.scala
@@ -18,26 +18,26 @@ package uk.gov.hmrc.uploaddocuments.controllers.internal
 
 import play.api.libs.json.JsValue
 import play.api.mvc.Action
-import uk.gov.hmrc.uploaddocuments.controllers.{BaseController, BaseControllerComponents}
+import uk.gov.hmrc.uploaddocuments.controllers.{BaseController, BaseControllerComponents, FileUploadsControllerHelper, JourneyContextControllerHelper}
 import uk.gov.hmrc.uploaddocuments.models._
-import uk.gov.hmrc.uploaddocuments.services.FileUploadService
+import uk.gov.hmrc.uploaddocuments.services.{FileUploadService, JourneyContextService}
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
 @Singleton
 class CallbackFromUpscanController @Inject()(components: BaseControllerComponents,
-                                             fileUploadService: FileUploadService)
-                                            (implicit ec: ExecutionContext) extends BaseController(components) {
+                                             override val journeyContextService: JourneyContextService,
+                                             override val fileUploadService: FileUploadService)
+                                            (implicit ec: ExecutionContext) extends BaseController(components) with FileUploadsControllerHelper with JourneyContextControllerHelper {
 
   // POST /callback-from-upscan/journey/:journeyId/:nonce
-  final def callbackFromUpscan(journeyId: JourneyId, nonce: String): Action[JsValue] =
-    Action.async(parse.tolerantJson) { implicit request =>
-      withJsonBody[UpscanNotification] { payload =>
-        implicit val journey: JourneyId = journeyId
-        withJourneyContext { implicit journeyContext =>
-          fileUploadService.markFileWithUpscanResponseAndNotifyHost(payload, Nonce(nonce)).map { _ => NoContent }
-        }
+  final def callbackFromUpscan(journeyId: JourneyId, nonce: String): Action[JsValue] = Action.async(parse.tolerantJson) { implicit request =>
+    withJsonBody[UpscanNotification] { payload =>
+      implicit val journey: JourneyId = journeyId
+      withJourneyContext { implicit journeyContext =>
+        fileUploadService.markFileWithUpscanResponseAndNotifyHost(payload, Nonce(nonce)).map { _ => NoContent }
       }
     }
+  }
 }

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/internal/InitializeController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/internal/InitializeController.scala
@@ -29,29 +29,27 @@ import scala.concurrent.ExecutionContext
 @Singleton
 class InitializeController @Inject()(components: BaseControllerComponents,
                                      fileUploadService: FileUploadService,
-                                     journeyContextService: JourneyContextService)(implicit ec: ExecutionContext)
-    extends BaseController(components) {
+                                     journeyContextService: JourneyContextService)
+                                    (implicit ec: ExecutionContext) extends BaseController(components) {
 
   // POST /internal/initialize
-  final val initialize: Action[JsValue] =
-    Action.async(parse.tolerantJson) { implicit request =>
-      withJsonBody[FileUploadInitializationRequest] { payload =>
-        whenInSession { implicit journeyId =>
-          whenAuthenticatedInBackchannel {
-            for {
-              _ <- journeyContextService.putJourneyContext(FileUploadContext(payload.config, HostService(request)))
-              _ <- fileUploadService.putFiles(FileUploads(payload))
-            } yield {
-              val url = if (payload.config.features.showUploadMultiple) {
-                mainRoutes.StartController.start.url
-              } else {
-                mainRoutes.ChooseSingleFileController.showChooseFile.url
-              }
-              Created.withHeaders(HeaderNames.LOCATION -> url)
+  final val initialize: Action[JsValue] = Action.async(parse.tolerantJson) { implicit request =>
+    withJsonBody[FileUploadInitializationRequest] { payload =>
+      whenInSession { implicit journeyId =>
+        whenAuthenticatedInBackchannel {
+          for {
+            _ <- journeyContextService.putJourneyContext(FileUploadContext(payload.config, HostService(request)))
+            _ <- fileUploadService.putFiles(FileUploads(payload))
+          } yield {
+            val url = if (payload.config.features.showUploadMultiple) {
+              mainRoutes.StartController.start.url
+            } else {
+              mainRoutes.ChooseSingleFileController.showChooseFile.url
             }
+            Created.withHeaders(HeaderNames.LOCATION -> url)
           }
         }
       }
     }
-
+  }
 }

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/internal/WipeOutController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/internal/WipeOutController.scala
@@ -18,22 +18,22 @@ package uk.gov.hmrc.uploaddocuments.controllers.internal
 
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.uploaddocuments.controllers.{BaseController, BaseControllerComponents}
+import uk.gov.hmrc.uploaddocuments.repository.JourneyCacheRepository
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class WipeOutController @Inject()(components: BaseControllerComponents)(implicit ec: ExecutionContext)
-    extends BaseController(components) {
+class WipeOutController @Inject()(components: BaseControllerComponents,
+                                  journeyCacheRepository: JourneyCacheRepository)
+                                 (implicit ec: ExecutionContext) extends BaseController(components) {
 
   // POST /internal/wipe-out
-  final val wipeOut: Action[AnyContent] =
-    Action.async { implicit request =>
-      whenInSession { implicit journeyId =>
-        whenAuthenticatedInBackchannel {
-          components.newJourneyCacheRepository.deleteEntity(journeyId.value).map(_ => NoContent)
-        }
+  final val wipeOut: Action[AnyContent] = Action.async { implicit request =>
+    whenInSession { implicit journeyId =>
+      whenAuthenticatedInBackchannel {
+        journeyCacheRepository.deleteEntity(journeyId.value).map(_ => NoContent)
       }
     }
-
+  }
 }

--- a/test/uk/gov/hmrc/uploaddocuments/services/FileVerificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/uploaddocuments/services/FileVerificationServiceSpec.scala
@@ -61,7 +61,7 @@ class FileVerificationServiceSpec extends UnitSpec with MockFileUploadService wi
 
         "throw Match Error" in new TestFixture {
 
-          mockWithFiles(journeyId)(Some(FileUploads()))
+          mockWithFiles(journeyId)(Future.successful(Some(FileUploads())))
 
           intercept[MatchError](await(actual))
         }
@@ -75,7 +75,7 @@ class FileVerificationServiceSpec extends UnitSpec with MockFileUploadService wi
 
             "execute the whenReady result" in new TestFixture {
 
-              mockWithFiles(journeyId)(Some(FileUploads(Seq(acceptedFileUpload))))
+              mockWithFiles(journeyId)(Future.successful(Some(FileUploads(Seq(acceptedFileUpload)))))
 
               await(actual) shouldBe s"ResponseReceived for ${acceptedFileUpload.reference}"
             }
@@ -87,8 +87,8 @@ class FileVerificationServiceSpec extends UnitSpec with MockFileUploadService wi
 
               val postedFileSameReference = fileUploadPosted.copy(reference = acceptedFileUpload.reference)
 
-              mockWithFiles(journeyId)(Some(FileUploads(Seq(postedFileSameReference)))).repeat(3)
-              mockWithFiles(journeyId)(Some(FileUploads(Seq(acceptedFileUpload))))
+              mockWithFiles(journeyId)(Future.successful(Some(FileUploads(Seq(postedFileSameReference))))).repeat(3)
+              mockWithFiles(journeyId)(Future.successful(Some(FileUploads(Seq(acceptedFileUpload)))))
 
               await(actual) shouldBe s"ResponseReceived for ${acceptedFileUpload.reference}"
             }
@@ -103,7 +103,7 @@ class FileVerificationServiceSpec extends UnitSpec with MockFileUploadService wi
 
               val postedFileSameReference = fileUploadPosted.copy(reference = acceptedFileUpload.reference)
 
-              mockWithFiles(journeyId)(Some(FileUploads(Seq(postedFileSameReference)))).repeat(6)
+              mockWithFiles(journeyId)(Future.successful(Some(FileUploads(Seq(postedFileSameReference))))).repeat(6)
 
               await(actual) shouldBe "TimedOut"
             }
@@ -118,7 +118,7 @@ class FileVerificationServiceSpec extends UnitSpec with MockFileUploadService wi
 
         "return None" in {
 
-          mockWithFiles(journeyId)(None)
+          mockWithFiles(journeyId)(Future.successful(None))
           await(TestFileVerificationService.getFileVerificationStatus("foo")) shouldBe None
         }
       }
@@ -129,7 +129,7 @@ class FileVerificationServiceSpec extends UnitSpec with MockFileUploadService wi
 
           "return None" in {
 
-            mockWithFiles(journeyId)(Some(FileUploads()))
+            mockWithFiles(journeyId)(Future.successful(Some(FileUploads())))
             await(TestFileVerificationService.getFileVerificationStatus("foo")) shouldBe None
           }
         }
@@ -145,7 +145,7 @@ class FileVerificationServiceSpec extends UnitSpec with MockFileUploadService wi
                 allowedFilesTypesHint = Some(hint)
               )))
 
-              mockWithFiles(journeyId)(Some(FileUploads(Seq(acceptedFileUpload))))
+              mockWithFiles(journeyId)(Future.successful(Some(FileUploads(Seq(acceptedFileUpload)))))
 
               await(TestFileVerificationService.getFileVerificationStatus(acceptedFileUpload.reference)(context, messages, journeyId)) shouldBe Some(
                 FileVerificationStatus(
@@ -167,7 +167,7 @@ class FileVerificationServiceSpec extends UnitSpec with MockFileUploadService wi
                 val extensions = "Extensions"
                 val context = journeyContext.copy(config = fileUploadSessionConfig.copy(allowedFileExtensions = Some(extensions)))
 
-                mockWithFiles(journeyId)(Some(FileUploads(Seq(acceptedFileUpload))))
+                mockWithFiles(journeyId)(Future.successful(Some(FileUploads(Seq(acceptedFileUpload)))))
 
                 await(TestFileVerificationService.getFileVerificationStatus(acceptedFileUpload.reference)(context, messages, journeyId)) shouldBe
                   Some(
@@ -185,7 +185,7 @@ class FileVerificationServiceSpec extends UnitSpec with MockFileUploadService wi
 
               "return FileVerificationStatus with the allowedContentTypes as the allowedFileTypesHint" in {
 
-                mockWithFiles(journeyId)(Some(FileUploads(Seq(acceptedFileUpload))))
+                mockWithFiles(journeyId)(Future.successful(Some(FileUploads(Seq(acceptedFileUpload)))))
 
                 await(TestFileVerificationService.getFileVerificationStatus(acceptedFileUpload.reference)) shouldBe Some(
                   FileVerificationStatus(

--- a/test/uk/gov/hmrc/uploaddocuments/services/mocks/MockFileUploadService.scala
+++ b/test/uk/gov/hmrc/uploaddocuments/services/mocks/MockFileUploadService.scala
@@ -18,27 +18,27 @@ package uk.gov.hmrc.uploaddocuments.services.mocks
 
 import org.scalamock.handlers.{CallHandler1, CallHandler2, CallHandler3}
 import org.scalamock.scalatest.MockFactory
-import uk.gov.hmrc.mongo.cache.CacheItem
 import uk.gov.hmrc.uploaddocuments.models.{FileUploads, JourneyId}
 import uk.gov.hmrc.uploaddocuments.services.FileUploadService
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 trait MockFileUploadService extends MockFactory {
 
   val mockFileUploadService = mock[FileUploadService]
 
-  def mockGetFiles(journeyId: JourneyId)(response: Future[Option[FileUploads]]): CallHandler1[JourneyId, Future[Option[FileUploads]]] =
+  def mockGetFiles(journeyId: JourneyId)(response: => Future[Option[FileUploads]]): CallHandler1[JourneyId, Future[Option[FileUploads]]] =
     (mockFileUploadService.getFiles(_: JourneyId)).expects(journeyId).returning(response)
 
-  def mockPutFiles(journeyId: JourneyId, request: FileUploads)(response: Future[FileUploads]): CallHandler2[FileUploads, JourneyId, Future[FileUploads]] =
+  def mockPutFiles(journeyId: JourneyId, request: FileUploads)(response: => Future[FileUploads]): CallHandler2[FileUploads, JourneyId, Future[FileUploads]] =
     (mockFileUploadService.putFiles(_: FileUploads)(_: JourneyId)).expects(request, journeyId).returning(response)
 
-  def mockWithFiles[T](journeyId: JourneyId)(files: Option[FileUploads]): CallHandler3[Future[T], FileUploads => Future[T], JourneyId, Future[T]] = {
+  def mockWithFiles[T](journeyId: JourneyId)(files: => Future[Option[FileUploads]])
+                      (implicit ec: ExecutionContext): CallHandler3[Future[T], FileUploads => Future[T], JourneyId, Future[T]] = {
     (mockFileUploadService.withFiles[T](_: Future[T])(_: FileUploads => Future[T])(_: JourneyId))
       .expects(*, *, journeyId)
       .onCall { mock =>
-        files match {
+        files.flatMap {
           case Some(value) =>
             mock.productElement(1).asInstanceOf[FileUploads => Future[T]](value)
           case None =>


### PR DESCRIPTION
- Also, only mix-in controller helper methods when needed by introducing two new traits.