### PR TITLE
[CSDR-2086] change how wipe-out works, deactivate context instead of deleting, remove only file uploads, redirect user to sendoffUrl if context deactivated

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Minimal payload example:
 |`continueWhenFullUrl`|string|optional|A host URL where to proceed after user clicks `Continue` (or selects `No` in the form) and there are no more file slots left, defaults to `continueUrl`|
 |`continueWhenEmptyUrl`|string|optional|A host URL where to proceed after user clicks `Continue` (or selects `No` in the form) and none file has been uploaded yet, defaults to `continueUrl`|
 |`backlinkUrl`|string|optional|A host URL where to retreat when user clicks backlink, otherwise a default `history.back()` action.|
+|`sendoffUrl`|string|optional|A host URL where to send off the user if the current session has been deactivated (wiped out), defaults to `content.serviceUrl` or `http://www.gov.uk` if missing.|
 |`minimumNumberOfFiles`|number|optional|Minimum number of files user can upload, usually 0 or 1, defaults to 1|
 |`maximumNumberOfFiles`|number|optional|Maximum number of files user can upload, defaults to 10|
 |`initialNumberOfEmptyRows`|number|optional|Initial number of empty choose file rows, defaults to 3|

--- a/app/uk/gov/hmrc/uploaddocuments/controllers/BaseController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/BaseController.scala
@@ -32,7 +32,7 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.Future
 
 @Singleton
-class BaseControllerComponents @Inject()(
+class BaseControllerComponents @Inject() (
   val appConfig: AppConfig,
   val authConnector: FrontendAuthConnector,
   val environment: Environment,
@@ -58,5 +58,7 @@ abstract class BaseController(
 
   final def preferUploadMultipleFiles(implicit rh: RequestHeader): Boolean =
     rh.cookies.get(COOKIE_JSENABLED).isDefined
+
+  final def govukStartUrl: String = components.appConfig.govukStartUrl
 
 }

--- a/app/uk/gov/hmrc/uploaddocuments/models/FileUploadSessionConfig.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/models/FileUploadSessionConfig.scala
@@ -32,6 +32,8 @@ final case class FileUploadSessionConfig(
     None, // optional url to continue after user selects YES answer in the form
   continueWhenFullUrl: Option[String] = None, // optional url to continue after all possible files has been uploaded
   continueWhenEmptyUrl: Option[String] = None, // optional url to continue after none file uploaded
+  sendoffUrl: Option[String] =
+    None, // optional url where to send off the user when the session has been cleared by the host service
   minimumNumberOfFiles: Int = defaultMinimumNumberOfFiles,
   maximumNumberOfFiles: Int = defaultMaximumNumberOfFiles,
   initialNumberOfEmptyRows: Int = defaultInitialNumberOfEmptyRows,
@@ -79,6 +81,7 @@ object FileUploadSessionConfig {
         and (JsPath \ "continueAfterYesAnswerUrl").readNullable[String]
         and (JsPath \ "continueWhenFullUrl").readNullable[String]
         and (JsPath \ "continueWhenEmptyUrl").readNullable[String]
+        and (JsPath \ "sendoffUrl").readNullable[String]
         and (JsPath \ "minimumNumberOfFiles").readWithDefault[Int](defaultMinimumNumberOfFiles)
         and (JsPath \ "maximumNumberOfFiles").readWithDefault[Int](defaultMaximumNumberOfFiles)
         and (JsPath \ "initialNumberOfEmptyRows").readWithDefault[Int](defaultInitialNumberOfEmptyRows)
@@ -97,6 +100,7 @@ object FileUploadSessionConfig {
         and (JsPath \ "continueAfterYesAnswerUrl").writeNullable[String]
         and (JsPath \ "continueWhenFullUrl").writeNullable[String]
         and (JsPath \ "continueWhenEmptyUrl").writeNullable[String]
+        and (JsPath \ "sendoffUrl").writeNullable[String]
         and (JsPath \ "minimumNumberOfFiles").write[Int]
         and (JsPath \ "maximumNumberOfFiles").write[Int]
         and (JsPath \ "initialNumberOfEmptyRows").write[Int]

--- a/app/uk/gov/hmrc/uploaddocuments/services/FileUploadService.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/services/FileUploadService.scala
@@ -49,6 +49,9 @@ class FileUploadService @Inject() (
   def putFiles(files: FileUploads)(implicit journeyId: JourneyId): Future[FileUploads] =
     repo.put(journeyId.value)(DataKeys.uploadedFiles, files).map(_ => files)
 
+  def wipeOut()(implicit journeyId: JourneyId): Future[Unit] =
+    repo.delete(journeyId.value)(DataKeys.uploadedFiles)
+
   def withFiles[T](
     journeyNotFoundResult: => Future[T]
   )(f: FileUploads => Future[T])(implicit journeyId: JourneyId): Future[T] =

--- a/app/uk/gov/hmrc/uploaddocuments/services/JourneyContextService.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/services/JourneyContextService.scala
@@ -36,10 +36,20 @@ class JourneyContextService @Inject() (repo: JourneyCacheRepository)(implicit ec
 
   def withJourneyContext[T](
     journeyNotFoundResult: => Future[T]
-  )(f: FileUploadContext => Future[T])(implicit journeyId: JourneyId): Future[T] =
+  )(
+    journeyNotActiveResult: FileUploadContext => Future[T]
+  )(body: FileUploadContext => Future[T])(implicit journeyId: JourneyId): Future[T] =
     getJourneyContext().flatMap(_.fold {
-      Logger.error("[withFiles] No files exist for the supplied journeyID")
+      Logger.error("[withFiles] No files exist for the supplied journeyID, redirecting user to gov.uk")
       Logger.debug(s"[withFiles] journeyId: '$journeyId'")
       journeyNotFoundResult
-    }(f))
+    } { c =>
+      if (c.active)
+        body(c)
+      else {
+        Logger.info("[withFiles] Files are already not available, sending user off to the host.")
+        Logger.debug(s"[withFiles] journeyId: '$journeyId'")
+        journeyNotActiveResult(c)
+      }
+    })
 }

--- a/it/uk/gov/hmrc/uploaddocuments/controllers/FilePostedControllerISpec.scala
+++ b/it/uk/gov/hmrc/uploaddocuments/controllers/FilePostedControllerISpec.scala
@@ -10,12 +10,14 @@ class FilePostedControllerISpec extends ControllerISpecBase {
       "set current file upload status as posted and return 201 Created" in {
 
         setContext()
-        setFileUploads(FileUploads(files =
-          Seq(
-            FileUpload.Initiated(Nonce.Any, Timestamp.Any, "11370e18-6e24-453e-b45a-76d3e32ea33d"),
-            FileUpload.Posted(Nonce.Any, Timestamp.Any, "2b72fe99-8adf-4edb-865e-622ae710f77c")
+        setFileUploads(
+          FileUploads(files =
+            Seq(
+              FileUpload.Initiated(Nonce.Any, Timestamp.Any, "11370e18-6e24-453e-b45a-76d3e32ea33d"),
+              FileUpload.Posted(Nonce.Any, Timestamp.Any, "2b72fe99-8adf-4edb-865e-622ae710f77c")
+            )
           )
-        ))
+        )
 
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
 

--- a/it/uk/gov/hmrc/uploaddocuments/controllers/internal/WipeOutControllerISpec.scala
+++ b/it/uk/gov/hmrc/uploaddocuments/controllers/internal/WipeOutControllerISpec.scala
@@ -16,7 +16,7 @@ class WipeOutControllerISpec extends ControllerISpecBase {
         result.status shouldBe 404
       }
 
-      "return 204 and cleanup session state" in {
+      "return 204 and cleanup uploaded files" in {
 
         val context = FileUploadContext(fileUploadSessionConfig)
         val fileUploads = FileUploads(files =
@@ -32,8 +32,8 @@ class WipeOutControllerISpec extends ControllerISpecBase {
         val result = await(backchannelRequest("/wipe-out").post(""))
         result.status shouldBe 204
 
-        getContext() shouldBe None
         getFileUploads() shouldBe None
+        getContext() shouldBe Some(context.deactivate())
       }
     }
   }

--- a/it/uk/gov/hmrc/uploaddocuments/services/JourneyContextServiceISpec.scala
+++ b/it/uk/gov/hmrc/uploaddocuments/services/JourneyContextServiceISpec.scala
@@ -22,12 +22,14 @@ import uk.gov.hmrc.uploaddocuments.repository.JourneyCacheRepository
 import uk.gov.hmrc.uploaddocuments.repository.JourneyCacheRepository.DataKeys
 import uk.gov.hmrc.uploaddocuments.support.TestData._
 import uk.gov.hmrc.uploaddocuments.support.{AppISpec, LogCapturing}
+import play.api.mvc.Results
+import scala.concurrent.Future
 
 class JourneyContextServiceISpec extends AppISpec with LogCapturing with BeforeAndAfterEach {
 
   implicit lazy val ec = scala.concurrent.ExecutionContext.Implicits.global
 
-  lazy val repo = app.injector.instanceOf[JourneyCacheRepository]
+  lazy val repo                      = app.injector.instanceOf[JourneyCacheRepository]
   lazy val testjourneyContextService = app.injector.instanceOf[JourneyContextService]
 
   override def beforeEach(): Unit = {
@@ -83,6 +85,34 @@ class JourneyContextServiceISpec extends AppISpec with LogCapturing with BeforeA
         await(repo.collection.countDocuments().toFuture()) shouldBe 1
 
         await(testjourneyContextService.getJourneyContext()(journeyId)) shouldBe Some(fileUploadContext)
+      }
+    }
+
+    "calling .withJourneyContext()" should {
+      "provide journey context if exists" in {
+        await(testjourneyContextService.putJourneyContext(fileUploadContext)(journeyId))
+        await(
+          testjourneyContextService.withJourneyContext(Future.successful(Results.NotImplemented))(c =>
+            Future.successful(Results.NonAuthoritativeInformation)
+          )(c => Future.successful(Results.Ok))(journeyId)
+        ) shouldBe Results.Ok
+      }
+
+      "return journeyNotFoundResult if journey context not exists" in {
+        await(
+          testjourneyContextService.withJourneyContext(Future.successful(Results.NotImplemented))(c =>
+            Future.successful(Results.NonAuthoritativeInformation)
+          )(c => Future.successful(Results.Ok))(journeyId)
+        ) shouldBe Results.NotImplemented
+      }
+
+      "return journeyNotActiveResult if journey context not active anymore" in {
+        await(testjourneyContextService.putJourneyContext(fileUploadContext.deactivate())(journeyId))
+        await(
+          testjourneyContextService.withJourneyContext(Future.successful(Results.NotImplemented))(c =>
+            Future.successful(Results.NonAuthoritativeInformation)
+          )(c => Future.successful(Results.Ok))(journeyId)
+        ) shouldBe Results.NonAuthoritativeInformation
       }
     }
   }


### PR DESCRIPTION
This PR fixes UCDF behaviour when user tries to enter /choose-files or any other URL after the session has been wiped out. Before session was deleted and user was redirected to the GOV.UK. Now, when session is deactivated and user is send off back to host service, if possible. In case session does not exists (not initialised) the bahaviour stays the same as before.